### PR TITLE
Adapt model for OCSVM

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -409,8 +409,8 @@ async fn main() -> std::io::Result<()> {
             ).into()
         });
 
-    log::info!("Starting SVM model server on http://0.0.0.0:8001");
-    log::info!("Health check server on http://0.0.0.0:3001");
+    log::info!("Starting SVM model server on http://0.0.0.0:8004");
+    log::info!("Health check server on http://0.0.0.0:3002");
 
 
     // Start the health check server in a separate thread
@@ -422,7 +422,7 @@ async fn main() -> std::io::Result<()> {
                 App::new().service(health_check)
             })
             .workers(1) // Use only one worker for health checks
-            .bind(("0.0.0.0", 3001))
+            .bind(("0.0.0.0", 3002))
             .unwrap()
             .run()
             .await
@@ -438,7 +438,7 @@ async fn main() -> std::io::Result<()> {
             .service(predict)
             .service(train)
     })
-    .bind(("0.0.0.0", 8001))?
+    .bind(("0.0.0.0", 8004))?
     .run()
     .await
 }

--- a/src/signals/mod.rs
+++ b/src/signals/mod.rs
@@ -240,7 +240,8 @@ impl Discharge {
     }
 }
 
-pub fn get_dataset(discharges: Vec<Discharge>) -> Dataset<f64, bool, Ix1> {
+
+pub fn get_dataset_one_class(discharges: Vec<Discharge>) -> Dataset<f64, (), Ix1> {
     // Process each discharge separately and combine the results
     let mut all_records = Vec::new();
     let mut all_targets = Vec::new();
@@ -276,7 +277,6 @@ pub fn get_dataset(discharges: Vec<Discharge>) -> Dataset<f64, bool, Ix1> {
         for window_idx in 0..windows_count {
             let mut window_features =
                 Vec::with_capacity(SignalType::count() * FeatureType::count());
-            let is_anomaly = discharge.class == DisruptionClass::Anomaly;
 
             // Collect features for all signal types in order
             for signal_type in &[
@@ -326,7 +326,7 @@ pub fn get_dataset(discharges: Vec<Discharge>) -> Dataset<f64, bool, Ix1> {
 
             // Add this window's data to the combined results
             all_records.push(window_features);
-            all_targets.push(is_anomaly);
+            all_targets.push(());
         }
     }
 
@@ -347,9 +347,6 @@ pub fn get_dataset(discharges: Vec<Discharge>) -> Dataset<f64, bool, Ix1> {
         records.shape()[0],
         targets.len()
     );
-
-    let num_of_true = targets.iter().filter(|&&x| x == true).count();
-    log::info!("Number of true targets: {}", num_of_true);
 
     Dataset::new(records, targets)
 }


### PR DESCRIPTION
This pull request refactors the SVM model implementation to use a one-class classification approach instead of a binary classification approach. It also updates the server configuration to use new ports for both the SVM model server and the health check server. The most important changes include replacing the `get_dataset` function with `get_dataset_one_class`, modifying the SVM model training logic, and updating server port bindings.

### Refactoring for One-Class Classification:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL6-R12): Replaced calls to `get_dataset` with `get_dataset_one_class` in `process_prediction_request` and `process_training_request`. Updated prediction logic to use `dataset.records()` instead of the dataset directly. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL6-R12) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL235-R242) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL283-L287)
* [`src/signals/mod.rs`](diffhunk://#diff-977eb00cf2fec2385694752e89ebe05cf74c28b6b14319591cb91572ed3fef31L243-R244): Replaced `get_dataset` with `get_dataset_one_class`, which now uses `()` as the target type instead of `bool`. Removed the anomaly determination logic and adjusted dataset creation accordingly. [[1]](diffhunk://#diff-977eb00cf2fec2385694752e89ebe05cf74c28b6b14319591cb91572ed3fef31L243-R244) [[2]](diffhunk://#diff-977eb00cf2fec2385694752e89ebe05cf74c28b6b14319591cb91572ed3fef31L279) [[3]](diffhunk://#diff-977eb00cf2fec2385694752e89ebe05cf74c28b6b14319591cb91572ed3fef31L329-R329) [[4]](diffhunk://#diff-977eb00cf2fec2385694752e89ebe05cf74c28b6b14319591cb91572ed3fef31L351-L353)

### SVM Model Training Updates:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL283-L287): Modified the SVM model training logic to use `nu_weight(0.1)` instead of `pos_neg_weights`. Updated the target type in the SVM model to `Pr` for compatibility with one-class classification.

### Server Configuration Updates:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL411-R413): Updated the SVM model server port from `8001` to `8004` and the health check server port from `3001` to `3002`. Adjusted bindings accordingly. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL411-R413) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL424-R425) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL440-R441)